### PR TITLE
Wagner-feat: implementa geração de etiquetas em PDF com nome do produto e imagem

### DIFF
--- a/src/gerador_pdf.py
+++ b/src/gerador_pdf.py
@@ -1,0 +1,18 @@
+import os
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+def gerar_pdf(produtos, imagens):
+    if not os.path.exists("output"):
+        os.makedirs("output")
+
+    for i, produto in enumerate(produtos):
+        nome_pdf = f"output/etiqueta_{i}.pdf"
+        c = canvas.Canvas(nome_pdf, pagesize=letter)
+        
+        # Aqui supõe-se que 'produto' é um dict ou pd.Series com chave 'nome'
+        nome_produto = produto['nome'] if isinstance(produto, dict) else str(produto)
+        
+        c.drawString(100, 750, f"Produto: {nome_produto}")
+        c.drawImage(imagens[i], 100, 600, width=200, height=200)
+        c.save()


### PR DESCRIPTION
### O que foi feito

- Adicionada a função `gerar_pdf(produtos, imagens)` responsável por criar etiquetas em formato PDF.
- Para cada produto da lista, é gerado um arquivo `etiqueta_X.pdf` contendo:
  - O nome do produto (exibido no topo da página).
  - A imagem correspondente (como código de barras ou QR Code).

### Tecnologias utilizadas

- `reportlab`: geração e manipulação de PDFs
- `os`: verificação e criação da pasta de saída `output/`

### Como testar

1. Garanta que exista uma lista `produtos` com dicionários (ou pandas Series) contendo a chave `'nome'`.
2. Garanta também uma lista `imagens` com o caminho das imagens a serem inseridas.
3. Execute a função no `main.py` ou em script separado:

   ```python
   gerar_pdf(produtos, imagens)
